### PR TITLE
Support multi-string TXT records

### DIFF
--- a/src/Handlers/Raw/RawDataResponse.php
+++ b/src/Handlers/Raw/RawDataResponse.php
@@ -215,8 +215,13 @@ class RawDataResponse
                 break;
 
             case RecordTypes::TXT:
-                $strLen = ord($this->readResponse());
-                $text = $this->readResponse($strLen);
+                $totalLength = $headerData['length'];
+                $text = '';
+                do {
+                    $totalLength--;
+                    $strLen = ord($this->readResponse());
+                    $text .= $this->readResponse($strLen);
+                } while (strlen($text) < $totalLength);
                 $result['txt'] = DnsUtils::sanitizeRecordTxt($text);
                 break;
 


### PR DESCRIPTION
The TCP/UDP handlers currently do not support TXT records consisting of multiple strings (for data exceeding 255 bytes, as defined in [RFC 4408](https://datatracker.ietf.org/doc/html/rfc4408#section-3.1.3)). This change concatenates the strings as intended.